### PR TITLE
Fix typo in danger zone dialog

### DIFF
--- a/pages/danger_zone.py
+++ b/pages/danger_zone.py
@@ -19,7 +19,7 @@ with st.container(border=True):
 
     @st.dialog("Nuke database", width="small")
     def nuke_db():
-        st.markdown("Are your sure to **nuke** the databse???")
+        st.markdown("Are your sure to **nuke** the database???")
         ut.h_spacer(2)
         col = st.columns([3, 1])
         with col[0]:


### PR DESCRIPTION
## Summary
- fix mispelled word 'databse' in `danger_zone.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e93786f84832dbac737f50f3b89b1