### PR TITLE
Show success message in game history

### DIFF
--- a/pages/game_results.py
+++ b/pages/game_results.py
@@ -70,6 +70,10 @@ def init_session_state():
         st.session_state.last_cache_clear = time.time()
     if "refresh_record_form" not in st.session_state:
         st.session_state.refresh_record_form = False
+    if "action_message" not in st.session_state:
+        st.session_state.action_message = ""
+    if "results_tab" not in st.session_state:
+        st.session_state.results_tab = "Game History"
 
 
 def clear_performance_caches():
@@ -127,7 +131,10 @@ def delete_game_dialog(game_data: Dict, game_number: int):
         ):
             if db.delete_game_from_database(game_id):
                 clear_performance_caches()
-                st.success("Game deleted successfully!")
+                st.session_state.action_message = (
+                    f"Game #{game_number} deleted successfully!"
+                )
+                st.session_state.results_tab = "Game History"
                 st.rerun()
             else:
                 st.error("Failed to delete game. Please try again.")
@@ -306,7 +313,10 @@ def edit_game_dialog(game_data: Dict, game_number: int):
                 edit_notes or "",
             ):
                 clear_performance_caches()
-                st.success("Game updated successfully!")
+                st.session_state.action_message = (
+                    f"Game #{game_number} updated successfully!"
+                )
+                st.session_state.results_tab = "Game History"
                 st.rerun()
             else:
                 st.error("Failed to update game. Please try again.")
@@ -578,7 +588,11 @@ def display_new_game_form():
                     del st.session_state[submission_key]
                     st.session_state.game_form_counter += 1
                     clear_performance_caches()
-                    st.success("Game saved successfully!")
+                    new_count = db.get_games_count()
+                    st.session_state.action_message = (
+                        f"Game #{new_count} recorded successfully!"
+                    )
+                    st.session_state.results_tab = "Game History"
                     st.rerun()
                 else:
                     del st.session_state[submission_key]
@@ -591,7 +605,8 @@ init_session_state()
 # Main app layout
 st.header("Game Results")
 tab1, tab2 = st.tabs(
-    [s.center(16, "\u2001") for s in ["Game History", "Record New Game"]]
+    [s.center(16, "\u2001") for s in ["Game History", "Record New Game"]],
+    key="results_tab",
 )
 
 # Game history tab with advanced optimizations
@@ -599,6 +614,10 @@ with tab1:
     col1, col2 = st.columns([2, 1])
     with col1:
         st.markdown("#### Game History")
+    # Success message just below the header
+    if st.session_state.get("action_message"):
+        st.success(st.session_state.action_message)
+        st.session_state.action_message = ""
 
     # Performance controls
     with col2:


### PR DESCRIPTION
## Summary
- show a confirmation message after editing, deleting or creating a game
- automatically switch back to the Game History tab after saving a new game

## Testing
- `python -m py_compile pages/game_results.py`

------
https://chatgpt.com/codex/tasks/task_b_684ed8dc0518832da94c3cca5e26e08c