### PR TITLE
Optimize statistics data queries

### DIFF
--- a/functions/database.py
+++ b/functions/database.py
@@ -1089,3 +1089,37 @@ def get_single_game_details(game_id: int) -> dict:
         logger.error(f"Error fetching game {game_id} details: {e}")
         st.error(f"Error fetching game details: {e}")
         return {"scores": [], "settings": []}
+
+
+def get_all_scores() -> pd.DataFrame:
+    """Return all game scores with player names."""
+    conn = st.connection("mysql", type="sql")
+    try:
+        query = """
+            SELECT s.game_id, s.player_id, p.name AS player_name, s.score
+            FROM datalings_game_scores s
+            JOIN datalings_players p ON s.player_id = p.id
+        """
+        return conn.query(query, ttl=0)
+    except Exception as e:
+        logger.error(f"Error fetching all game scores: {e}")
+        return pd.DataFrame()
+
+
+def get_all_game_setting_values() -> pd.DataFrame:
+    """Return all game setting values for all games."""
+    conn = st.connection("mysql", type="sql")
+    try:
+        query = """
+            SELECT sv.game_id, sv.setting_id, gs.name AS setting_name,
+                   gs.type AS setting_type, sv.value_text, sv.value_number,
+                   sv.value_boolean, sv.value_time_minutes
+            FROM datalings_game_setting_values sv
+            JOIN datalings_game_settings gs ON sv.setting_id = gs.id
+            ORDER BY sv.game_id, gs.position
+        """
+        return conn.query(query, ttl=0)
+    except Exception as e:
+        logger.error(f"Error fetching all game setting values: {e}")
+        return pd.DataFrame()
+

--- a/pages/game_results.py
+++ b/pages/game_results.py
@@ -70,6 +70,8 @@ def init_session_state():
         st.session_state.last_cache_clear = time.time()
     if "refresh_record_form" not in st.session_state:
         st.session_state.refresh_record_form = False
+    if "refresh_statistics" not in st.session_state:
+        st.session_state.refresh_statistics = False
 
 
 def clear_performance_caches():
@@ -127,6 +129,7 @@ def delete_game_dialog(game_data: Dict, game_number: int):
         ):
             if db.delete_game_from_database(game_id):
                 clear_performance_caches()
+                st.session_state.refresh_statistics = True
                 st.success("Game deleted successfully!")
                 st.rerun()
             else:
@@ -306,6 +309,7 @@ def edit_game_dialog(game_data: Dict, game_number: int):
                 edit_notes or "",
             ):
                 clear_performance_caches()
+                st.session_state.refresh_statistics = True
                 st.success("Game updated successfully!")
                 st.rerun()
             else:
@@ -578,6 +582,7 @@ def display_new_game_form():
                     del st.session_state[submission_key]
                     st.session_state.game_form_counter += 1
                     clear_performance_caches()
+                    st.session_state.refresh_statistics = True
                     st.success("Game saved successfully!")
                     st.rerun()
                 else:

--- a/pages/statistics.py
+++ b/pages/statistics.py
@@ -28,6 +28,9 @@ def load_all_game_data():
     if games_df.empty:
         return pd.DataFrame(), pd.DataFrame(), {}
 
+    scores_all = db.get_all_scores()
+    settings_all = db.get_all_game_setting_values()
+
     all_game_data = []
     game_stats = []
     host_selections = []
@@ -36,34 +39,41 @@ def load_all_game_data():
     for _, game_row in games_df.iterrows():
         game_id = int(game_row["id"])
         game_date = game_row["game_date"]
-        game_details = db.get_game_details(game_id)
 
-        # Game-level stats
-        scores = game_details.get("scores", [])
-        if scores:
-            game_scores = [score["score"] for score in scores]
+        scores = scores_all[scores_all["game_id"] == game_id]
+        settings = settings_all[settings_all["game_id"] == game_id]
+
+        if not scores.empty:
+            game_scores = scores["score"].tolist()
             game_duration = None
             num_ages = None
             host_selection = None
 
-            # Extract settings more efficiently
-            for setting in game_details.get("settings", []):
+            for _, setting in settings.iterrows():
                 setting_name = setting["setting_name"]
                 setting_name_lower = setting_name.lower()
 
                 if "duration" in setting_name_lower or "time" in setting_name_lower:
                     try:
-                        game_duration = float(setting["value"])
-                    except:
+                        game_duration = float(
+                            setting["value_time_minutes"] or setting["value_number"]
+                        )
+                    except Exception:
                         pass
                 elif "# ages" in setting_name_lower or setting_name_lower == "ages":
                     try:
-                        num_ages = int(float(setting["value"]))
+                        num_ages = int(
+                            float(setting["value_number"] or setting["value_text"])
+                        )
                         total_ages_played += num_ages
-                    except:
+                    except Exception:
                         pass
                 elif "host" in setting_name_lower:
-                    host_selection = setting["value"]
+                    host_selection = (
+                        setting["value_text"]
+                        or setting["value_number"]
+                        or setting["value_time_minutes"]
+                    )
                     host_selections.append(host_selection)
 
             game_total_score = sum(game_scores)
@@ -84,15 +94,14 @@ def load_all_game_data():
                 }
             )
 
-            # Individual score data
-            for score_data in scores:
+            for _, score_row in scores.iterrows():
                 all_game_data.append(
                     {
                         "game_id": game_id,
                         "game_date": game_date,
-                        "player_id": score_data["player_id"],
-                        "player_name": score_data["player_name"],
-                        "score": score_data["score"],
+                        "player_id": score_row["player_id"],
+                        "player_name": score_row["player_name"],
+                        "score": score_row["score"],
                         "duration": game_duration,
                         "num_ages": num_ages,
                         "host_selection": host_selection,
@@ -208,6 +217,9 @@ def create_metric_tile(title, value, border=True):
 
 
 # Load data ####################################################################
+if st.session_state.get("refresh_statistics"):
+    load_all_game_data.clear()
+    st.session_state.refresh_statistics = False
 scores_df, games_df, summary_stats = load_all_game_data()
 
 if scores_df.empty:


### PR DESCRIPTION
## Summary
- fetch all scores and settings in single queries
- update statistics page to use the new helpers
- clear cached statistics when games change

## Testing
- `python -m py_compile pages/statistics.py functions/database.py`

------
https://chatgpt.com/codex/tasks/task_b_684eda271ae4832d8607594f33dff0bb