### PR TITLE
Update ranking display when game counts differ

### DIFF
--- a/functions/utils.py
+++ b/functions/utils.py
@@ -78,7 +78,7 @@ def create_sidebar() -> None:
     if st.session_state["authentication_status"]:
         authenticator = st.session_state["auth"]
         authenticator.logout(
-            button_name=f"logout {st.session_state.get("username")}",
+            button_name=f"logout {st.session_state.get('username')}",
             location="sidebar",
             use_container_width=True,
         )


### PR DESCRIPTION
## Summary
- adjust ranking points chart to optionally hide average score
- detect if each player played the same number of games
- fix quoting in logout button name

## Testing
- `python -m py_compile datalings.py pages/*.py functions/*.py`

------
https://chatgpt.com/codex/tasks/task_b_6850757d14b4832db3829daf8f77c0d0